### PR TITLE
Rocket Boots and Flying Carpet happens before ori air jumps

### DIFF
--- a/Abilities/AirJump.cs
+++ b/Abilities/AirJump.cs
@@ -49,7 +49,7 @@ namespace OriMod.Abilities {
     internal override void Tick() {
       if (CanUse && input.jump.JustPressed) {
         if (player.jumpAgainBlizzard || player.jumpAgainCloud || player.jumpAgainFart || player.jumpAgainSail ||
-            player.jumpAgainSandstorm || player.mount.Active) return;
+            player.jumpAgainSandstorm || player.canCarpet || player.canRocket || player.mount.Active) return;
         SetState(State.Active);
         currentCount++;
         _gravityDirection = (sbyte)player.gravDir;


### PR DESCRIPTION
Rocket Boots and Flying Carpet accessories now happen before ori air jumps instead of at the same time.