### PR TITLE
Fixed some bugs with Sein

### DIFF
--- a/Projectiles/Minions/Sein.cs
+++ b/Projectiles/Minions/Sein.cs
@@ -44,6 +44,7 @@ public abstract class Sein : Minion {
     Projectile.ignoreWater = true;
     Projectile.ContinuouslyUpdateDamageStats = true;
     Projectile.DamageType = DamageClass.Summon;
+    Projectile.minion = true;
 
     byte type = SeinType;
     _data = SeinData.All[type - 1];

--- a/Projectiles/Minions/Sein.cs
+++ b/Projectiles/Minions/Sein.cs
@@ -22,7 +22,7 @@ public abstract class Sein : Minion {
   public sealed override void SetStaticDefaults() {
     Main.projFrames[Projectile.type] = 3;
     Main.projPet[Projectile.type] = true;
-    ProjectileID.Sets.MinionSacrificable[Projectile.type] = true;
+    //ProjectileID.Sets.MinionSacrificable[Projectile.type] = true;
     ProjectileID.Sets.CultistIsResistantTo[Projectile.type] = true;
     ProjectileID.Sets.MinionTargettingFeature[Projectile.type] = true; //This is necessary for right-click targeting
   }
@@ -39,8 +39,8 @@ public abstract class Sein : Minion {
 
   public override void SetDefaults() {
     Projectile.netImportant = true;
-    Projectile.minion = true;
-    Projectile.minionSlots = -0.001f;
+    //Projectile.minion = true;
+    //Projectile.minionSlots = -0.001f;
     Projectile.penetrate = -1;
     Projectile.timeLeft = 18000;
     Projectile.tileCollide = false;

--- a/Projectiles/Minions/Sein.cs
+++ b/Projectiles/Minions/Sein.cs
@@ -22,7 +22,6 @@ public abstract class Sein : Minion {
   public sealed override void SetStaticDefaults() {
     Main.projFrames[Projectile.type] = 3;
     Main.projPet[Projectile.type] = true;
-    //ProjectileID.Sets.MinionSacrificable[Projectile.type] = true;
     ProjectileID.Sets.CultistIsResistantTo[Projectile.type] = true;
     ProjectileID.Sets.MinionTargettingFeature[Projectile.type] = true; //This is necessary for right-click targeting
   }
@@ -39,8 +38,6 @@ public abstract class Sein : Minion {
 
   public override void SetDefaults() {
     Projectile.netImportant = true;
-    //Projectile.minion = true;
-    //Projectile.minionSlots = -0.001f;
     Projectile.penetrate = -1;
     Projectile.timeLeft = 18000;
     Projectile.tileCollide = false;

--- a/Projectiles/Minions/Sein.cs
+++ b/Projectiles/Minions/Sein.cs
@@ -42,6 +42,8 @@ public abstract class Sein : Minion {
     Projectile.timeLeft = 18000;
     Projectile.tileCollide = false;
     Projectile.ignoreWater = true;
+    Projectile.ContinuouslyUpdateDamageStats = true;
+    Projectile.DamageType = DamageClass.Summon;
 
     byte type = SeinType;
     _data = SeinData.All[type - 1];
@@ -400,12 +402,10 @@ public abstract class Sein : Minion {
 
     float _summon_damage_mul = _summon_damage.Additive * _summon_damage.Multiplicative;
 
-    int dmg = (int)(((Projectile.damage+_summon_damage.Base) * _summon_damage_mul + _summon_damage.Flat) *
-                    (!AutoFire ? ManualShootDamageMultiplier : 1));
+    int dmg = (int)(Projectile.damage * (!AutoFire ? ManualShootDamageMultiplier : 1));
 
 
     Projectile spiritFlame = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, shootVel, _spiritFlameType, dmg, Projectile.knockBack, Projectile.owner);
-    spiritFlame.originalDamage = _data.damage;
     spiritFlame.netUpdate = true;
     Projectile.netUpdate = true;
     if (npc is null) {

--- a/Projectiles/Minions/Sein.cs
+++ b/Projectiles/Minions/Sein.cs
@@ -399,10 +399,6 @@ public abstract class Sein : Minion {
     shootVel = (shootVel * _data.projectileSpeedStart).RotatedBy(rotation);
     Projectile.velocity += shootVel.Normalized() * -0.2f;
 
-    var _summon_damage = Player.GetDamage<SummonDamageClass>();
-
-    float _summon_damage_mul = _summon_damage.Additive * _summon_damage.Multiplicative;
-
     int dmg = (int)(Projectile.damage * (!AutoFire ? ManualShootDamageMultiplier : 1));
 
 


### PR DESCRIPTION
- Most damage multipliers, including the boost when firing manually, were not being applied; fixed
- When all of your minion slots are full,
  - Summoning Sein would kill an older minion; fixed
  - Summoning a new minion would kill Sein; not fixed
    - caused by `.minion = true`; removing would also prevent Sein from being dyed by critter shampoo
    - would have to either change how minions are spawned, apply dye to Sein manually, or include 
      Sein in some other dye group, like pets or light pets

This is my first time using github, sorry if I've done something the wrong way