### PR TITLE
Tweaked abilities, fixed bugs

### DIFF
--- a/Abilities/AirJump.cs
+++ b/Abilities/AirJump.cs
@@ -57,7 +57,10 @@ public sealed class AirJump : OriAbility, ILevelable {
       currentCount++;
       _gravityDirection = (sbyte)player.gravDir;
 
-      if (MaxJumps != 1 && currentCount == MaxJumps) {
+      if (abilities.glide) {
+        PlaySound("Ori/Glide/seinGlideStart" + _rand.NextNoRepeat(3), 0.8f);
+      }
+      else if (MaxJumps != 1 && currentCount == MaxJumps) {
         PlaySound("Ori/TripleJump/seinTripleJumps" + _rand.NextNoRepeat(5), 0.6f);
       }
       else {

--- a/Abilities/AirJump.cs
+++ b/Abilities/AirJump.cs
@@ -65,11 +65,8 @@ public sealed class AirJump : OriAbility, ILevelable {
       }
       return;
     }
-    if (IsGrounded || abilities.bash || abilities.launch || OnWall) {
-      currentCount = 0;
-      if (IsGrounded || abilities.bash || abilities.launch || abilities.climb) {
-        SetState(AbilityState.Inactive);
-      }
+    if (IsGrounded || abilities.bash || abilities.launch || abilities.climb) {
+      SetState(AbilityState.Inactive);
     }
     if (Active) {
       SetState(AbilityState.Ending);

--- a/Abilities/Bash.cs
+++ b/Abilities/Bash.cs
@@ -247,7 +247,6 @@ public sealed class Bash : OriAbility, ILevelable {
   private void End() {
     player.pulley = false;
     PlaySound("Ori/Bash/seinBashEnd" + _rand.NextNoRepeat(3), 0.5f);
-    oPlayer.UnrestrictedMovement = true;
 
     bool isNpc = BashEntity is NPC;
     NPC npc = (NPC)(isNpc ? BashEntity : null);

--- a/Abilities/Bash.cs
+++ b/Abilities/Bash.cs
@@ -363,8 +363,7 @@ public sealed class Bash : OriAbility, ILevelable {
       }
       else if (BufferDuration == MaxBufferDuration) {
         PlayLocalSound("Ori/Bash/bashNoTargetB", 0.35f);
-        StartCooldown();
-        EndCooldown(); // Make particles
+        abilities.RefreshParticles(Color.LightYellow);
       }
     }
     else if (InUse) {

--- a/Abilities/Bash.cs
+++ b/Abilities/Bash.cs
@@ -249,12 +249,15 @@ public sealed class Bash : OriAbility, ILevelable {
     PlaySound("Ori/Bash/seinBashEnd" + _rand.NextNoRepeat(3), 0.5f);
     oPlayer.UnrestrictedMovement = true;
 
+    bool isNpc = BashEntity is NPC;
+    NPC npc = (NPC)(isNpc ? BashEntity : null);
+
     Vector2 bashVector = new((float)(0 - Math.Cos(BashAngle)), (float)(0 - Math.Sin(BashAngle)));
     Vector2 playerBashVector = -bashVector * BashPlayerStrength;
     Vector2 npcBashVector = bashVector * BashNpcStrength;
     player.velocity = playerBashVector;
     player.position += playerBashVector * 3;
-    BashEntity.velocity = npcBashVector;
+    if (!isNpc || !npc.immortal) BashEntity.velocity = npcBashVector; // Don't knockback target dummies
     player.position += npcBashVector * 5;
     if (IsGrounded) {
       player.position.Y -= 1f;
@@ -263,7 +266,7 @@ public sealed class Bash : OriAbility, ILevelable {
     oPlayer.immuneTimer = 5;
 
     BashTarget.IsBashed = false;
-    if (IsLocal && Level >= 2 && BashEntity is NPC npc) {
+    if (IsLocal && Level >= 2 && isNpc) {
       player.ApplyDamageToNPC(npc, BashDamage, 0, 1, false);
     }
 

--- a/Abilities/Bash.cs
+++ b/Abilities/Bash.cs
@@ -337,6 +337,7 @@ public sealed class Bash : OriAbility, ILevelable {
       bool didBash = Start();
       if (didBash) {
         SetState(AbilityState.Starting);
+        RestoreAirJumps();
       }
       else if (!abilities.launch.CanUse) {
         PlayLocalSound("Ori/Bash/bashNoTargetB", 0.35f);

--- a/Abilities/Burrow.cs
+++ b/Abilities/Burrow.cs
@@ -201,7 +201,6 @@ public sealed class Burrow : OriAbility, ILevelable {
     velocity = velocity.Normalized() * Math.Max(velocity.Length(), BaseSpeed);
     player.velocity = velocity * SpeedExitMultiplier;
     player.direction = Math.Sign(velocity.X);
-    oPlayer.UnrestrictedMovement = true;
   }
 
   public override void UpdateUsing() {

--- a/Abilities/Burrow.cs
+++ b/Abilities/Burrow.cs
@@ -250,7 +250,7 @@ public sealed class Burrow : OriAbility, ILevelable {
       // Different frameY if this represents a partially filled bar
       int frameX = (int)Main.time % 30 / 10;
       int frameY = 0;
-      if (i * (UiIncrement + 1) > _breath) {
+      if ((i+1) * UiIncrement > _breath) {
         frameY = 4 - (int)_breath % UiIncrement / (UiIncrement / 5);
       }
 

--- a/Abilities/ChargeDash.cs
+++ b/Abilities/ChargeDash.cs
@@ -101,6 +101,7 @@ public sealed class ChargeDash : OriAbility {
       player.position = target.position;
       player.position.Y -= 32f;
       player.velocity = player.velocity.Normalized() * Speeds[^1];
+      RestoreAirJumps();
     }
     else if (Math.Abs(player.velocity.Y) < Math.Abs(player.velocity.X)) {
       // Reducing velocity. If intended direction is mostly flat (not moving upwards, not jumping), make it flat.

--- a/Abilities/ChargeJump.cs
+++ b/Abilities/ChargeJump.cs
@@ -111,7 +111,7 @@ public sealed class ChargeJump : OriAbility, ILevelable {
       }
       else {
         _currentGrace--;
-        if (_currentGrace < 0) {
+        if (_currentGrace < 0 || !input.charge.Current) {
           _currentCharge = 0;
           PlaySound("Ori/ChargeDash/seinChargeDashUncharge", 0.6f, .3f);
         }

--- a/Abilities/Climb.cs
+++ b/Abilities/Climb.cs
@@ -69,7 +69,7 @@ public sealed class Climb : OriAbility, ILevelable {
   }
 
   public override void UpdateEnding() {
-    player.velocity.X = wallDirection * 5f;
+    player.velocity.X = wallDirection * 3f;
     player.velocity.Y = -player.gravDir * 4f;
   }
 

--- a/Abilities/Climb.cs
+++ b/Abilities/Climb.cs
@@ -47,7 +47,7 @@ public sealed class Climb : OriAbility, ILevelable {
     if (IsCharging) {
       player.velocity.Y = 0;
     }
-    else if (player.controlUp) {
+    else if (player.controlUp || input.jump.Current) {
       player.velocity.Y += player.velocity.Y < (player.gravDir > 0 ? -2 : 4) ? 1 : -1;
     }
     else if (player.controlDown) {
@@ -58,6 +58,7 @@ public sealed class Climb : OriAbility, ILevelable {
     }
 
     player.gravity = 0;
+    player.jump = 0;
     player.runAcceleration = 0;
     player.maxRunSpeed = 0;
     player.direction = wallDirection;
@@ -102,10 +103,10 @@ public sealed class Climb : OriAbility, ILevelable {
         SetState(AbilityState.Inactive);
       }
     }
-    else if (!input.climb.Current || (!CanUse && !player.controlUp)) {
+    else if (!input.climb.Current || (!CanUse && !(player.controlUp || input.jump.Current))) {
       SetState(AbilityState.Inactive);
     }
-    else if (!CanUse && player.controlUp) {
+    else if (!CanUse && (player.controlUp || input.jump.Current)) {
       // Climb over top of things
       SetState(AbilityState.Ending);
     }

--- a/Abilities/Dash.cs
+++ b/Abilities/Dash.cs
@@ -33,6 +33,9 @@ public sealed class Dash : OriAbility, ILevelable {
   private static int Duration => Speeds.Length - 1;
 
   private sbyte _direction;
+  
+  internal ushort currentCount;
+  private int MaxDashes => 1;
 
   private readonly RandomChar _rand = new();
 
@@ -40,6 +43,7 @@ public sealed class Dash : OriAbility, ILevelable {
     _direction = (sbyte)(player.controlLeft ? -1 : player.controlRight ? 1 : player.direction);
     PlaySound("Ori/Dash/seinDash" + _rand.NextNoRepeat(3), 0.2f);
     player.pulley = false;
+    currentCount++;
   }
 
   public override void ReadPacket(BinaryReader r) {
@@ -65,7 +69,7 @@ public sealed class Dash : OriAbility, ILevelable {
     if (IsLocal) netUpdate = true;
   }
 
-  public override bool RefreshCondition() => abilities.bash || OnWall || IsGrounded || player.mount.Active;
+  public override bool RefreshCondition() => currentCount < MaxDashes || player.mount.Active;
 
   public override void PreUpdate() {
     if (abilities.chargeDash) {

--- a/Abilities/Dash.cs
+++ b/Abilities/Dash.cs
@@ -62,9 +62,6 @@ public sealed class Dash : OriAbility, ILevelable {
     }
     player.velocity.X = Speeds[stateTime] * 0.5f * _direction;
     player.velocity.Y = 0.25f * (stateTime + 1) * player.gravDir;
-    if (stateTime > 20) {
-      player.runSlowdown = 26f;
-    }
     if (IsLocal) netUpdate = true;
   }
 
@@ -83,7 +80,7 @@ public sealed class Dash : OriAbility, ILevelable {
     }
     if (!InUse) return;
     UpdateCooldown();
-    if (abilities.airJump) {
+    if (abilities.airJump || input.jump.JustPressed) {
       SetState(AbilityState.Inactive);
       player.velocity.X = Speeds[24] * _direction; // Rip hyperspeed dash-jump
       StartCooldown(); //force = true

--- a/Abilities/Dash.cs
+++ b/Abilities/Dash.cs
@@ -1,6 +1,7 @@
 using AnimLib.Abilities;
 using Microsoft.Xna.Framework;
 using OriMod.Utilities;
+using System;
 using System.IO;
 using Terraria;
 using Terraria.ModLoader;
@@ -86,7 +87,7 @@ public sealed class Dash : OriAbility, ILevelable {
     UpdateCooldown();
     if (abilities.airJump || input.jump.JustPressed) {
       SetState(AbilityState.Inactive);
-      player.velocity.X = Speeds[24] * _direction; // Rip hyperspeed dash-jump
+      player.velocity.X = Math.Min(Speeds[24], Math.Abs(player.velocity.X)) * _direction; // Rip hyperspeed dash-jump
       StartCooldown(); //force = true
     }
     else if (stateTime > Duration || OnWall || abilities.bash) {

--- a/Abilities/Glide.cs
+++ b/Abilities/Glide.cs
@@ -19,8 +19,8 @@ public sealed class Glide : OriAbility, ILevelable {
   public override bool Unlocked => Level > 0;
 
   public override bool CanUse =>
-    base.CanUse && !Ending && player.velocity.Y * Math.Sign(player.gravDir) > 0 && !player.mount.Active &&
-    !abilities.airJump && !abilities.bash && !abilities.burrow && !abilities.chargeDash && !abilities.chargeJump &&
+    base.CanUse && !Ending && !player.mount.Active &&
+    !abilities.bash && !abilities.burrow && !abilities.chargeDash && !abilities.chargeJump &&
     !abilities.climb && !abilities.dash && !abilities.launch && !abilities.stomp && !abilities.wallChargeJump &&
     !abilities.wallJump;
 
@@ -63,11 +63,11 @@ public sealed class Glide : OriAbility, ILevelable {
   }
 
   public override void PreUpdate() {
-    if (!InUse && CanUse && !OnWall && input.glide.Current) {
+    if (!InUse && CanUse && !IsGrounded && !OnWall && input.glide.Current) {
       SetState(AbilityState.Starting);
       return;
     }
-    if (abilities.dash || abilities.airJump || abilities.burrow || abilities.launch) {
+    if (abilities.dash || abilities.burrow || abilities.launch) {
       SetState(AbilityState.Inactive);
       return;
     }
@@ -83,7 +83,7 @@ public sealed class Glide : OriAbility, ILevelable {
         SetState(AbilityState.Inactive);
       }
     }
-    else if (player.velocity.Y * player.gravDir < 0 || OnWall || IsGrounded || !input.glide.Current) {
+    else if (OnWall || IsGrounded || !input.glide.Current) {
       SetState(AbilityState.Ending);
     }
   }

--- a/Abilities/Glide.cs
+++ b/Abilities/Glide.cs
@@ -26,8 +26,8 @@ public sealed class Glide : OriAbility, ILevelable {
 
   private static float RunSlowdown => 0.125f;
   private static float RunAcceleration => 0.2f;
-  private static int StartDuration => 8;
-  private static int EndDuration => 10;
+  private static int StartDuration => 5;
+  private static int EndDuration => 5;
 
   private readonly RandomChar _randStart = new();
   private readonly RandomChar _randActive = new();

--- a/Abilities/Glide.cs
+++ b/Abilities/Glide.cs
@@ -58,7 +58,6 @@ public sealed class Glide : OriAbility, ILevelable {
 
   public override void UpdateUsing() {
     player.maxFallSpeed = MathHelper.Clamp(player.gravity * 5, 1f, 2f);
-    if (oPlayer.UnrestrictedMovement) return;
     player.runSlowdown = RunSlowdown;
     player.runAcceleration = RunAcceleration;
   }

--- a/Abilities/Launch.cs
+++ b/Abilities/Launch.cs
@@ -145,7 +145,6 @@ public sealed class Launch : OriAbility {
 
   private void End() {
     player.velocity = LaunchDirection * 10;
-    oPlayer.UnrestrictedMovement = true;
     StartCooldown();
   }
 

--- a/Abilities/Launch.cs
+++ b/Abilities/Launch.cs
@@ -33,7 +33,7 @@ public sealed class Launch : OriAbility {
     !abilities.chargeJump && !abilities.climb &&
     !abilities.dash && !abilities.stomp && !abilities.wallChargeJump;
 
-  private ushort CurrentChain { get; set; }
+  public ushort CurrentChain { get; set; }
 
   private ushort MaxChain =>
     Level switch {
@@ -195,8 +195,6 @@ public sealed class Launch : OriAbility {
   }
 
   public override void UpdateCooldown() {
-    if (!IsGrounded && !abilities.bash) return;
-    EndCooldown();
-    CurrentChain = 0;
+    if (CurrentChain == 0) EndCooldown();
   }
 }

--- a/Abilities/Launch.cs
+++ b/Abilities/Launch.cs
@@ -149,7 +149,7 @@ public sealed class Launch : OriAbility {
   }
 
   public override void PreUpdate() {
-    if (CanUse && input.bash.JustPressed && IsLocal) {
+    if (CanUse && input.charge.Current && input.bash.JustPressed && IsLocal) {
       if (CurrentChain == 0) {
         PlayLocalSound("Ori/Bash/seinBashStartA", 0.5f);
       }

--- a/Abilities/Launch.cs
+++ b/Abilities/Launch.cs
@@ -155,6 +155,7 @@ public sealed class Launch : OriAbility {
       }
 
       SetState(AbilityState.Starting);
+      RestoreAirJumps();
       CurrentChain = 1;
     }
     else if (!InUse) return;

--- a/Abilities/OriAbility.cs
+++ b/Abilities/OriAbility.cs
@@ -11,6 +11,7 @@ public abstract class OriAbility : Ability<OriAbilityManager> {
 
   protected bool OnWall => oPlayer.OnWall;
   protected bool IsGrounded => oPlayer.IsGrounded;
+  protected void RestoreAirJumps() => oPlayer.RestoreAirJumps();
 
   protected void PlaySound(string path, float volume = 1, float pitch = 0)
     => oPlayer.PlaySound(path, volume, pitch);

--- a/Abilities/Stomp.cs
+++ b/Abilities/Stomp.cs
@@ -106,6 +106,7 @@ public sealed class Stomp : OriAbility, ILevelable {
       player.controlLeft = false;
       player.controlRight = false;
     }
+    player.controlJump = false;
     player.controlHook = false;
     player.controlMount = false;
     player.controlThrow = false;
@@ -135,6 +136,9 @@ public sealed class Stomp : OriAbility, ILevelable {
     else if (Starting) {
       if (stateTime > StartDuration) {
           SetState(AbilityState.Active);
+      }
+      if (abilities.airJump.state == AbilityState.Active) {
+          SetState(AbilityState.Inactive);
       }
     }
     else if (Active) {

--- a/Abilities/Stomp.cs
+++ b/Abilities/Stomp.cs
@@ -130,23 +130,25 @@ public sealed class Stomp : OriAbility, ILevelable {
         }
       }
       if (Starting) {
-          _currentHoldDown = 0;
+        _currentHoldDown = 0;
       }
     }
     else if (Starting) {
       if (stateTime > StartDuration) {
-          SetState(AbilityState.Active);
+        SetState(AbilityState.Active);
       }
       if (abilities.airJump.state == AbilityState.Active) {
-          SetState(AbilityState.Inactive);
+        SetState(AbilityState.Inactive);
+        StartCooldown();
       }
     }
     else if (Active) {
       if ((stateTime > MinDuration && !player.controlDown) || abilities.airJump) {
-          SetState(AbilityState.Inactive);
+        SetState(AbilityState.Inactive);
+        StartCooldown();
       }
       if (IsGrounded) {
-          EndStomp();
+        EndStomp();
       }
     }
   }

--- a/Abilities/Stomp.cs
+++ b/Abilities/Stomp.cs
@@ -85,7 +85,7 @@ public sealed class Stomp : OriAbility, ILevelable {
 
   internal void EndStomp() {
     PlaySound("Ori/Stomp/seinStompImpact" + _randEnd.NextNoRepeat(3), 0.9f);
-    abilities.airJump.currentCount = 0;
+    RestoreAirJumps();
     player.velocity = Vector2.Zero;
     Vector2 position = new(player.position.X, player.position.Y + 32);
     for (int i = 0; i < 25; i++) {

--- a/Abilities/Stomp.cs
+++ b/Abilities/Stomp.cs
@@ -120,7 +120,7 @@ public sealed class Stomp : OriAbility, ILevelable {
         if (input.stomp.JustPressed) {
           _currentHoldDown = 1;
         }
-        if (_currentHoldDown >= 1 && input.stomp.Current && IsLocal) {
+        if (_currentHoldDown >= 1 && player.controlDown && input.stomp.Current && IsLocal) {
           _currentHoldDown++;
           if (_currentHoldDown > HoldDownDelay) {
             _currentHoldDown = 0;

--- a/Abilities/WallJump.cs
+++ b/Abilities/WallJump.cs
@@ -60,7 +60,6 @@ public sealed class WallJump : OriAbility, ILevelable {
   public override void UpdateUsing() {
     player.velocity.X = WallJumpVelocity.X * -_wallDirection;
     player.direction = _wallDirection;
-    oPlayer.UnrestrictedMovement = true;
   }
 
   public override void PreUpdate() {

--- a/Animations/OriAnimationController.cs
+++ b/Animations/OriAnimationController.cs
@@ -78,7 +78,11 @@ public class OriAnimationController : AnimationController {
       return;
     }
     if (abilities.airJump) {
-      PlayTrack("AirJump", rotation: FrameTime * 0.6f * player.gravDir * player.direction);
+      if (abilities.glide) {
+        PlayTrack("GlideStart", frameIndex: abilities.airJump.Active ? 0 : null);
+      } else {
+        PlayTrack("AirJump", rotation: FrameTime * 0.6f * player.gravDir * player.direction);
+      }
       return;
     }
     if (abilities.burrow) {

--- a/Animations/OriAnimationSources.cs
+++ b/Animations/OriAnimationSources.cs
@@ -60,7 +60,7 @@ public sealed class PlayerAnim : AnimationSource {
       F(3, 13)
     ),
     ["GlideStart"] = Track.Range(LoopMode.None,
-      F(4, 0, 5), F(4, 2, 5)
+      F(4, 0, 2), F(4, 2, 2)
     ),
     ["GlideIdle"] = Track.Single(
       F(4, 3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,50 @@
+# v3.2.1.0
+
+## Feature update
+
+Reduced acceleration/slowdown while in the air
+Reduced traction on ice
+Stomp and Bash won't break target dummies
+Using an ability medallion while at or above its max level resets the ability to level zero
+Fixed damage flash
+Most abilities that recharge air jump now also recharge dash and launch
+
+#### Sein
+Damage multipliers are now applied properly
+Deals 1.4x damage when fired manually
+Summoning Sein when your minion slots are full won't despawn older minions
+
+#### Bash
+Can be buffered; hold bash to grab the next target that comes in range
+Launch is now activated with charge + bash
+Can be released sooner, and has longer immunity after release
+Added stress system; use bash too often, and it stops giving iframes
+Added config option for whether bash should aim from the bashed entity or the player
+
+#### Charge Dash
+Resets your velocity on contact with enemy, no more launching into space
+Costs slightly more mana, activates mana regen cooldown
+Targets the enemy closest to the mouse instead of the player
+
+#### Stomp
+Added keybind
+Disabled wings while stomping
+
+#### Glide
+Starts and ends much faster
+Can be used while moving upwards
+Air jump has a different animation if used while gliding
+
+#### Dash
+Can be cancelled with a jump from the ground
+Resets your velocity when cancelled
+
+#### Burrow
+Fast burrow is now activated by holding burrow instead of left click
+Slows down on sharp turns, or while not holding a direction
+
+---
+
 # v3.2.0.2
 
 ## Bugfix

--- a/Items/Abilities/AbilityMedallionBase.cs
+++ b/Items/Abilities/AbilityMedallionBase.cs
@@ -35,8 +35,9 @@ public abstract class AbilityMedallionBase : ModItem {
   /// <returns><see langword="true"/> if the player does not have the <see cref="Ability"/> at this <see cref="Level"/>; otherwise, <see langword="false"/>.</returns>
   public override bool CanUseItem(Player player) {
     // Can only use the item if the ability to be unlocked has not been unlocked
-    OriPlayer oPlayer = player.GetModPlayer<OriPlayer>();
-    return oPlayer.abilities[Id].Level < Level;
+    //OriPlayer oPlayer = player.GetModPlayer<OriPlayer>();
+    //return oPlayer.abilities[Id].Level < Level;
+    return true;
   }
 
   /// <summary>
@@ -49,7 +50,7 @@ public abstract class AbilityMedallionBase : ModItem {
     OriPlayer oPlayer = player.GetModPlayer<OriPlayer>();
     Ability ability = oPlayer.abilities[Id];
     if (ability is ILevelable levelable) {
-      levelable.Level++;
+      levelable.Level = levelable.Level < Level ? levelable.Level + 1 : 0;
       if (player.whoAmI == Main.myPlayer) {
         string key = $"Mods.OriMod.Lore.{ability.GetType().Name}.{levelable.Level}";
         if (Language.Exists(key)) {
@@ -59,9 +60,9 @@ public abstract class AbilityMedallionBase : ModItem {
       string strStart = player.whoAmI == Main.myPlayer ? "You" : $"{player.name} has";
       if (!Main.dedServ)
         Main.NewText(
-          levelable.Level == 1
-            ? $"{strStart} unlocked {NiceName(ability)}!"
-            : $"{strStart} upgraded {NiceName(ability)} to Level {levelable.Level}!", Color.LightGreen);
+          levelable.Level == 1 ? $"{strStart} unlocked {NiceName(ability)}!" :
+          levelable.Level == 0 ? $"{strStart} forgot {NiceName(ability)}!" : 
+          $"{strStart} upgraded {NiceName(ability)} to Level {levelable.Level}!", Color.LightGreen);
       return true;
     }
 

--- a/Items/Abilities/AbilityMedallionBase.cs
+++ b/Items/Abilities/AbilityMedallionBase.cs
@@ -29,18 +29,6 @@ public abstract class AbilityMedallionBase : ModItem {
   }
 
   /// <summary>
-  /// Returns <see langword="true"/> if the player does not have the <see cref="Ability"/> this Item represents upgraded to the <see cref="Ability.Level"/> this Item upgrades to.
-  /// </summary>
-  /// <param name="player">The <see cref="Player"/> using the item.</param>
-  /// <returns><see langword="true"/> if the player does not have the <see cref="Ability"/> at this <see cref="Level"/>; otherwise, <see langword="false"/>.</returns>
-  public override bool CanUseItem(Player player) {
-    // Can only use the item if the ability to be unlocked has not been unlocked
-    //OriPlayer oPlayer = player.GetModPlayer<OriPlayer>();
-    //return oPlayer.abilities[Id].Level < Level;
-    return true;
-  }
-
-  /// <summary>
   /// Increases the level of <paramref name="player"/>'s <see cref="Ability"/> this Item represents to by 1.
   /// <para>By increasing by 1, the player can level it multiple times if they skip one, rather than having their level skip.</para>
   /// </summary>

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -147,6 +147,16 @@ Mods: {
 						when inventory, menu or dialogue are open.
 						'''
 				}
+
+				bashMode: {
+					Label: Bash Targeting Mode
+					Tooltip:
+						'''
+						Determines whether bash should aim from
+						the player or the bashed target.
+						Default: Target 
+						'''
+				}
 			}
 		}
 

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -157,6 +157,15 @@ Mods: {
 						Default: Target 
 						'''
 				}
+
+				flashMode: {
+					Label: Damage Flash Mode
+					Tooltip:
+						'''
+						Determines what color the player should flash after taking damage.
+						Default: Transparent
+						'''
+				}
 			}
 		}
 

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -213,6 +213,7 @@ Mods: {
 			Feather.DisplayName: Feather (Glide)
 			Charge.DisplayName: Charge
 			Burrow.DisplayName: Burrow
+			Stomp.DisplayName: Stomp
 		}
 
 		Tiles.SpiritSapling.MapEntry: Spirit Sapling

--- a/Localization/ru-RU.hjson
+++ b/Localization/ru-RU.hjson
@@ -148,6 +148,16 @@ Mods: {
 						когда открыты инвентарь, меню или диалоги.
 						'''
 				}
+
+				bashMode: {
+					// Label: Bash Targeting Mode
+					/* Tooltip:
+						'''
+						Determines whether bash should aim from
+						the player or the bash target.
+						Default: Target 
+						''' */
+				}
 			}
 		}
 

--- a/Localization/ru-RU.hjson
+++ b/Localization/ru-RU.hjson
@@ -214,6 +214,7 @@ Mods: {
 			Feather.DisplayName: Перо (Планер)
 			Charge.DisplayName: Заряд прыжка/рывка
 			Burrow.DisplayName: Бурение
+			// Stomp.DisplayName: Stomp
 		}
 
 		Tiles.SpiritSapling.MapEntry: Саженец Древа Духов

--- a/Localization/ru-RU.hjson
+++ b/Localization/ru-RU.hjson
@@ -158,6 +158,15 @@ Mods: {
 						Default: Target 
 						''' */
 				}
+
+				flashMode: {
+					// Label: Damage Flash Mode
+					/* Tooltip:
+						'''
+						Determines what color the player should flash after taking damage.
+						Default: Transparent
+						''' */
+				}
 			}
 		}
 

--- a/Localization/ru-RU.hjson
+++ b/Localization/ru-RU.hjson
@@ -154,7 +154,7 @@ Mods: {
 					/* Tooltip:
 						'''
 						Determines whether bash should aim from
-						the player or the bash target.
+						the player or the bashed target.
 						Default: Target 
 						''' */
 				}

--- a/Networking/OriPlayerPacketHandler.cs
+++ b/Networking/OriPlayerPacketHandler.cs
@@ -18,7 +18,6 @@ internal class OriPlayerPacketHandler : PacketHandler {
     BitsByte flags = reader.ReadByte();
     bool oriSet = flags[0];
     bool transforming = flags[1];
-    bool unrestrictedMovement = flags[2];
     bool seinMinionActive = flags[3];
     bool mpcPlayerLight = flags[4];
     bool controls_blocked = flags[5];
@@ -30,7 +29,6 @@ internal class OriPlayerPacketHandler : PacketHandler {
 
     fromPlayer.IsOri = oriSet;
     fromPlayer.Transforming = transforming;
-    fromPlayer.UnrestrictedMovement = unrestrictedMovement;
     fromPlayer.transformTimer = transformTimer;
     fromPlayer.SeinMinionType = seinMinionType;
     fromPlayer.SeinMinionActive = seinMinionActive;
@@ -60,7 +58,6 @@ internal class OriPlayerPacketHandler : PacketHandler {
     BitsByte flags = new() {
       [0] = fromPlayer.IsOri,
       [1] = fromPlayer.Transforming,
-      [2] = fromPlayer.UnrestrictedMovement,
       [3] = fromPlayer.SeinMinionActive,
       [4] = fromPlayer.multiplayerPlayerLight,
       [5] = fromPlayer.controls_blocked

--- a/OriConfig.cs
+++ b/OriConfig.cs
@@ -54,6 +54,11 @@ public class OriConfigClient1 : ModConfig {
   [DefaultValue("Mouse"), OptionStrings(new[] { "WASD", "Mouse" })]
   public string burrowControls;
 
+  [LocalizedLabel(nameof(bashMode))]
+  [LocalizedTooltip(nameof(bashMode))]
+  [DefaultValue("Target"), OptionStrings(new[] { "Target", "Player" })]
+  public string bashMode;
+
   [LocalizedLabel(nameof(blockControlsInMenu))]
   [LocalizedTooltip(nameof(blockControlsInMenu))]
   [DefaultValue("false")]

--- a/OriConfig.cs
+++ b/OriConfig.cs
@@ -91,6 +91,11 @@ public class OriConfigClient1 : ModConfig {
   [DefaultValue(typeof(float), "0.65")]
   public float dyeLerp;
 
+  [LocalizedLabel(nameof(flashMode))]
+  [LocalizedTooltip(nameof(flashMode))]
+  [DefaultValue("Transparent"), OptionStrings(new[] { "Transparent", "Red", "Disabled" })]
+  public string flashMode;
+
   public override void OnLoaded() {
     OriMod.ConfigClient = this;
   }

--- a/OriInput.cs
+++ b/OriInput.cs
@@ -17,7 +17,7 @@ public sealed class OriInput : IEnumerable<Input> {
   public readonly Input dash = new(() => OriMod.dashKey.Current && !OriPlayer.Local.controls_blocked);
   public readonly Input climb = new(() => OriMod.climbKey.Current && !OriPlayer.Local.controls_blocked);
   public readonly Input glide = new(() => OriMod.featherKey.Current && !OriPlayer.Local.controls_blocked);
-  public readonly Input stomp = new(() => PlayerInput.Triggers.Current.Down && !OriPlayer.Local.controls_blocked);
+  public readonly Input stomp = new(() => OriMod.stompKey.Current && !OriPlayer.Local.controls_blocked);
   public readonly Input charge = new(() => OriMod.chargeKey.Current && !OriPlayer.Local.controls_blocked);
   public readonly Input burrow = new(() => OriMod.burrowKey.Current && !OriPlayer.Local.controls_blocked);
   public readonly Input leftClick = new(() => PlayerInput.Triggers.Current.MouseLeft && !OriPlayer.Local.controls_blocked);

--- a/OriLayers.cs
+++ b/OriLayers.cs
@@ -35,7 +35,9 @@ internal static class OriLayers {
       bool isTransformStart = !oPlayer.IsOri && oPlayer.Transforming;
 
       DrawData data = oPlayer.Animations.playerAnim.GetDrawData(drawInfo);
-      bool doFlash = player.immune && !player.immuneNoBlink;
+      bool doFlash = player.immune && !player.immuneNoBlink && OriMod.ConfigClient.flashMode != "Disabled";
+      Color flashColor = Color.Transparent;
+      if (OriMod.ConfigClient.flashMode == "Red") flashColor = Color.Red;
       if (oPlayer.armor_dye != player.dye[1].netID) {
         oPlayer.dye_shader = GameShaders.Armor.GetShaderFromItemId(player.dye[1].netID);
         oPlayer.armor_dye = player.dye[1].netID;
@@ -44,7 +46,7 @@ internal static class OriLayers {
       Color sprCol = Color.Lerp(oPlayer.SpriteColorPrimary, shColor,
         (!dyeEn || shColor == Color.White) ? 0 : oPlayer.DyeColorBlend);
       data.color = doFlash
-          ? Color.Lerp(sprCol, Color.Transparent, player.immuneAlpha / 255f)
+          ? Color.Lerp(sprCol, flashColor, player.immuneAlpha / 255f)
           : isTransformStart ? Color.White : sprCol;
       data.shader = dyeEn ? player.dye[1].dye : 0;
       data.origin.Y += 5 * player.gravDir;
@@ -55,7 +57,7 @@ internal static class OriLayers {
       // Secondary color layer, only used when IsOri is true (i.e. not during transform start)
       if (oPlayer.IsOri) {
         data.color = doFlash
-          ? Color.Lerp(oPlayer.SpriteColorSecondary, Color.Transparent, player.immuneAlpha / 255f)
+          ? Color.Lerp(oPlayer.SpriteColorSecondary, flashColor, player.immuneAlpha / 255f)
           : oPlayer.SpriteColorSecondary;
 
         data.texture = OriTextures.Instance.playerSecondary;

--- a/OriLayers.cs
+++ b/OriLayers.cs
@@ -35,7 +35,7 @@ internal static class OriLayers {
       bool isTransformStart = !oPlayer.IsOri && oPlayer.Transforming;
 
       DrawData data = oPlayer.Animations.playerAnim.GetDrawData(drawInfo);
-      bool doFlash = player.immune && oPlayer.immuneTimer == 0;
+      bool doFlash = player.immune && !player.immuneNoBlink;
       if (oPlayer.armor_dye != player.dye[1].netID) {
         oPlayer.dye_shader = GameShaders.Armor.GetShaderFromItemId(player.dye[1].netID);
         oPlayer.armor_dye = player.dye[1].netID;
@@ -44,7 +44,7 @@ internal static class OriLayers {
       Color sprCol = Color.Lerp(oPlayer.SpriteColorPrimary, shColor,
         (!dyeEn || shColor == Color.White) ? 0 : oPlayer.DyeColorBlend);
       data.color = doFlash
-          ? Color.Lerp(sprCol, Color.Red, player.immuneAlpha / 255f)
+          ? Color.Lerp(sprCol, Color.Transparent, player.immuneAlpha / 255f)
           : isTransformStart ? Color.White : sprCol;
       data.shader = dyeEn ? player.dye[1].dye : 0;
       data.origin.Y += 5 * player.gravDir;
@@ -55,7 +55,7 @@ internal static class OriLayers {
       // Secondary color layer, only used when IsOri is true (i.e. not during transform start)
       if (oPlayer.IsOri) {
         data.color = doFlash
-          ? Color.Lerp(oPlayer.SpriteColorSecondary, Color.Red, player.immuneAlpha / 255f)
+          ? Color.Lerp(oPlayer.SpriteColorSecondary, Color.Transparent, player.immuneAlpha / 255f)
           : oPlayer.SpriteColorSecondary;
 
         data.texture = OriTextures.Instance.playerSecondary;

--- a/OriMod.cs
+++ b/OriMod.cs
@@ -115,6 +115,11 @@ public sealed class OriMod : Mod {
   /// </summary>
   public static ModKeybind burrowKey;
 
+    /// <summary>
+  /// Key used for activating <see cref="Abilities.Stomp"/>.
+  /// </summary>
+  public static ModKeybind stompKey;
+
   public override void Load() {
     //SoulLinkKey = RegisterKeybind(instance, "SoulLink", "E");
     bashKey = RegisterKeybind(instance, "Bash", "Mouse2");
@@ -123,6 +128,7 @@ public sealed class OriMod : Mod {
     featherKey = RegisterKeybind(instance, "Feather", "LeftShift");
     chargeKey = RegisterKeybind(instance, "Charge", "W");
     burrowKey = RegisterKeybind(instance, "Burrow", "LeftControl");
+    stompKey = RegisterKeybind(instance, "Stomp", "S");
     if (!Main.dedServ) {
       AddEquipTexture(instance, "OriMod/PlayerEffects/OriHead", EquipType.Head, null, "OriHead",
         GetEquipTexture(instance, "OriHead", EquipType.Head));
@@ -146,6 +152,7 @@ public sealed class OriMod : Mod {
     featherKey = null;
     chargeKey = null;
     burrowKey = null;
+    stompKey = null;
     //SoulLinkKey = null;
     ConfigClient = null;
   }

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -232,7 +232,14 @@ public sealed class OriPlayer : ModPlayer {
   /// <summary>
   /// When greater than 0, sets <see cref="Player.immune"/> to true.
   /// </summary>
-  internal int immuneTimer;
+  internal int immuneTimer {
+    get => Player.immuneTime;
+    set {
+      Player.immuneTime = value;
+      Player.immune = true;
+      Player.immuneNoBlink = true;
+    }
+  }
 
   private readonly RandomChar _randJump = new();
   private readonly RandomChar _randHurt = new();
@@ -425,12 +432,6 @@ public sealed class OriPlayer : ModPlayer {
 
     if (Transforming) {
       immuneTimer = 2;
-    }
-
-    if (immuneTimer > 1) {
-      immuneTimer--;
-      Player.immune = true;
-      Player.immuneNoBlink = true;
     }
 
     if (Main.netMode != NetmodeID.Server) {

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -235,7 +235,7 @@ public sealed class OriPlayer : ModPlayer {
   internal int immuneTimer {
     get => Player.immuneTime;
     set {
-      Player.immuneTime = value;
+      if (Player.immuneTime < value) Player.immuneTime = value;
       Player.immune = true;
       Player.immuneNoBlink = true;
     }

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -557,8 +557,8 @@ public sealed class OriPlayer : ModPlayer {
       Player.jumpSpeedBoost += 2f;
 
       if (IsGrounded) {
-        Player.runAcceleration = Math.Min(MathF.Pow(Player.runAcceleration,3f)*980f,0.5f);
-        Player.runSlowdown = Math.Min(MathF.Pow(Player.runSlowdown,2f)*25f,1f);
+        Player.runAcceleration = Math.Max(Math.Min(MathF.Pow(Player.runAcceleration,3f)*980f,0.5f),Player.runAcceleration);
+        Player.runSlowdown = Math.Max(Math.Min(MathF.Pow(Player.runSlowdown,2f)*25f,1f),Player.runSlowdown);
       } else {
         Player.runAcceleration = 0.3f;
         Player.runSlowdown = 0.5f;

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -189,18 +189,6 @@ public sealed class OriPlayer : ModPlayer {
   private int _carpet_remaining = -1;
 
   /// <summary>
-  /// When true, the player will not be slowed down (sets <see cref="Player.runSlowdown"/> to 0 every frame).
-  /// </summary>
-  public bool UnrestrictedMovement {
-    get => _unrestrictedMovement;
-    set {
-      if (value == _unrestrictedMovement) return;
-      _netUpdate = true;
-      _unrestrictedMovement = value;
-    }
-  }
-
-  /// <summary>
   /// Info about if this player has a <see cref="Projectiles.Minions.Sein"/> minion summoned. Used to prevent having more than one Sein summoned per player.
   /// </summary>
   public bool SeinMinionActive {
@@ -310,7 +298,6 @@ public sealed class OriPlayer : ModPlayer {
 
   private OriAnimationController _anim;
   private bool _isOri;
-  private bool _unrestrictedMovement;
   private bool _seinMinionActive;
   private int _seinMinionId;
   private int _seinMinionType;
@@ -410,7 +397,6 @@ public sealed class OriPlayer : ModPlayer {
   internal void ResetData() {
     IsOri = false;
     HasTransformedOnce = false;
-    UnrestrictedMovement = false;
     SeinMinionActive = false;
     SeinMinionType = 0;
     abilities.ResetAllAbilities();
@@ -564,16 +550,13 @@ public sealed class OriPlayer : ModPlayer {
     if (IsOri && !Transforming) {
       #region Default Spirit Run Speeds
 
-      Player.runAcceleration = 0.5f;
       Player.maxRunSpeed += 2f;
       Player.noFallDmg = true;
       LowerGravityTo(0.35f);
       Player.jumpSpeedBoost += 2f;
-      if (IsGrounded || Player.controlLeft || Player.controlRight) {
-        UnrestrictedMovement = false;
-      }
 
-      Player.runSlowdown = UnrestrictedMovement ? 0 : 1;
+      Player.runAcceleration = IsGrounded ? 0.5f : 0.3f;
+      Player.runSlowdown = IsGrounded ? 1f : 0.5f;
 
       #endregion
 
@@ -736,12 +719,6 @@ public sealed class OriPlayer : ModPlayer {
 
     modifiers.DisableDust();
     modifiers.DisableSound();
-  }
-
-  public override void OnHurt(Player.HurtInfo info) {
-    if (!IsOri) return;
-
-    UnrestrictedMovement = true;
   }
 
   public override void PostHurt(Player.HurtInfo info) {

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -560,8 +560,8 @@ public sealed class OriPlayer : ModPlayer {
         Player.runAcceleration = Math.Max(Math.Min(MathF.Pow(Player.runAcceleration,3f)*980f,0.5f),Player.runAcceleration);
         Player.runSlowdown = Math.Max(Math.Min(MathF.Pow(Player.runSlowdown,2f)*25f,1f),Player.runSlowdown);
       } else {
-        Player.runAcceleration = 0.3f;
-        Player.runSlowdown = 0.5f;
+        Player.runAcceleration = (Player.runAcceleration > 0.01 && Player.runAcceleration < 0.3) ? 0.3f : Player.runAcceleration;
+        Player.runSlowdown = (Player.runAcceleration > 0.01 && Player.runAcceleration < 0.5) ? 0.5f : Player.runAcceleration;;
       }
       #endregion
 

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -710,6 +710,7 @@ public sealed class OriPlayer : ModPlayer {
   public void RestoreAirJumps() {
     abilities.airJump.currentCount = 0;
     abilities.dash.currentCount = 0;
+    abilities.launch.CurrentChain = 0;
   }
 
   public override void FrameEffects() {

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -556,9 +556,13 @@ public sealed class OriPlayer : ModPlayer {
       LowerGravityTo(0.35f);
       Player.jumpSpeedBoost += 2f;
 
-      Player.runAcceleration = IsGrounded ? 0.5f : 0.3f;
-      Player.runSlowdown = IsGrounded ? 1f : 0.5f;
-
+      if (IsGrounded) {
+        Player.runAcceleration = Math.Min(MathF.Pow(Player.runAcceleration,3f)*980f,0.5f);
+        Player.runSlowdown = Math.Min(MathF.Pow(Player.runSlowdown,2f)*25f,1f);
+      } else {
+        Player.runAcceleration = 0.3f;
+        Player.runSlowdown = 0.5f;
+      }
       #endregion
 
       if (IsLocal && OriMod.ConfigClient.smoothCamera) {

--- a/OriPlayer.cs
+++ b/OriPlayer.cs
@@ -640,6 +640,8 @@ public sealed class OriPlayer : ModPlayer {
       IsGrounded = CheckGrounded();
       OnWall = CheckOnWall();
 
+      if (IsGrounded || OnWall) RestoreAirJumps();
+
       // Footstep effects
       if (Main.dedServ || !IsGrounded) return;
       bool doDust = false;
@@ -700,6 +702,14 @@ public sealed class OriPlayer : ModPlayer {
       Player.position.Y + (Player.gravDir < 0f ? -1f : 2f)
     ).ToTileCoordinates();
     return WorldGen.SolidTile(p.X, p.Y + 1) && WorldGen.SolidTile(p.X, p.Y + 2);
+  }
+
+  /// <summary>
+  /// Refreshes your airborne abilities, allowing you to jump and dash again before touching the ground.
+  /// </summary>
+  public void RestoreAirJumps() {
+    abilities.airJump.currentCount = 0;
+    abilities.dash.currentCount = 0;
   }
 
   public override void FrameEffects() {

--- a/Projectiles/Abilities/ChargeDashProjectile.cs
+++ b/Projectiles/Abilities/ChargeDashProjectile.cs
@@ -34,7 +34,7 @@ public sealed class ChargeDashProjectile : OriAbilityProjectile {
   public override void OnHitNPC(NPC target, NPC.HitInfo modifiers, int damageDone) {
     ChargeDash cDash = abilities.chargeDash;
     if (cDash.NpcIsTarget(target)) {
-      cDash.End();
+      cDash.End(true);
     }
   }
 }

--- a/Projectiles/Abilities/StompEnd.cs
+++ b/Projectiles/Abilities/StompEnd.cs
@@ -57,6 +57,7 @@ public sealed class StompEnd : OriAbilityProjectile {
   }
 
   private void ModifyHitAny(Entity target) {
+    if (target is NPC npc && npc.immortal) return; // Don't knockback target dummies
     Vector2 vector = target.Center - aPlayer.Player.Center;
     float dist = target.Distance(aPlayer.Player.Center);
     float kb = Knockback * (160.0f - dist) / 160.0f;

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
 author = Fro Zen, TwiliChaos
-version = 3.2.0.2
+version = 3.2.1.0
 displayName = Arrival Of The Blind Forest
 homepage = https://forums.terraria.org/index.php?threads/arrival-of-the-blind-forest.72356/
 includePDB = true

--- a/description.txt
+++ b/description.txt
@@ -32,6 +32,50 @@ simply loved Ori and we wanted to make it work in Terraria.
 If you enjoy this mod, we encourage you to play
 Ori and the Blind Forest, and Ori and the Will of the Wisps.
 
+--- v3.2.1.0 ---
+--- Feature update ---
+
+Reduced acceleration/slowdown while in the air
+Reduced traction on ice
+Stomp and Bash won't break target dummies
+Using an ability medallion while at or above its max level resets the ability to level zero
+Fixed damage flash
+Most abilities that recharge air jump now also recharge dash and launch
+
+Sein:
+- Damage multipliers are now applied properly
+- Deals 1.4x damage when fired manually
+- Summoning Sein when your minion slots are full won't despawn older minions
+
+Bash:
+- Can be buffered; hold bash to grab the next target that comes in range
+- Launch is now activated with charge + bash
+- Can be released sooner, and has longer immunity after release
+- Added stress system; use bash too often, and it stops giving iframes
+- Added config option for whether bash should aim from the bashed entity or the player
+
+Charge Dash:
+- Resets your velocity on contact with enemy, no more launching into space
+- Costs slightly more mana, activates mana regen cooldown
+- Targets the enemy closest to the mouse instead of the player
+
+Stomp:
+- Added keybind
+- Disabled wings while stomping
+
+Glide:
+- Starts and ends much faster
+- Can be used while moving upwards
+- Air jump has a different animation if used while gliding
+
+Dash:
+- Can be cancelled with a jump from the ground
+- Resets your velocity when cancelled
+
+Burrow:
+- Fast burrow is now activated by holding burrow instead of left click
+- Slows down on sharp turns, or while not holding a direction
+
 --- v3.2.0.2 ---
 --- Bugfix ---
 


### PR DESCRIPTION
Reduced acceleration/slowdown while in the air
Reduced traction on ice
Stomp and Bash won't break target dummies
Using an ability medallion while at or above its max level resets the ability to level zero
Fixed damage flash
Most abilities that recharge air jump now also recharge dash and launch

Bash
- Can be buffered; hold bash to grab the next target that comes in range 
  - Launch is now activated with charge + bash
- Can be released sooner, and has longer immunity after release
- Added stress system; use bash too often, and it stops giving iframes
- Added config option for whether bash should aim from the bashed entity or the player

Charge Dash
- Resets your velocity on contact with enemy, no more launching into space
- Costs slightly more mana, activates mana regen cooldown
- Targets the enemy closest to the mouse instead of the player

Stomp
- Added keybind
- Disabled wings while stomping

Glide
- Starts and ends much faster
- Can be used while moving upwards
- Air jump has a different animation if used while gliding

Dash
- Can be cancelled with a jump from the ground
- Resets your velocity when cancelled

Burrow
- Fast burrow is now activated by holding burrow instead of left click
- Slows down on sharp turns, or while not holding a direction

Because of the new config options, russian translations are out of date